### PR TITLE
Update dockerfile

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,5 +1,5 @@
 ## Build
-FROM golang:1.16-buster AS build
+FROM golang:1.17-buster AS build
 
 WORKDIR /app
 


### PR DESCRIPTION
## Update dockerfile
Dockerfile golang version update 1.16 to 1.17

## Fix Below Error on Ubuntu 22.04
```bash
4.191 note: module requires Go 1.17
9.061 make: *** [Makefile:16: build] Error 2
------
dockerfile:8
--------------------
   6 |     RUN apt-get update && apt-get install unzip && rm -rf /var/lib/apt/lists/*
   7 |     COPY ./ ./
   8 | >>> RUN make build
   9 |     RUN chmod +x ./get_chrome.sh && ./get_chrome.sh
  10 |
--------------------
ERROR: failed to solve: process "/bin/sh -c make build" did not complete successfully: exit code: 2
```